### PR TITLE
site_positions and precision bugs fixed

### DIFF
--- a/src/kite_wrapper.jl
+++ b/src/kite_wrapper.jl
@@ -189,7 +189,8 @@ function site_positions(h) # site positions for each orbital in the TB matrix
     position_atoms = h.lattice.unitcell.sites
     num_orbitals = Quantica.norbitals(h) # vector of num_orbitals at site i
     for i in 1:length(position_atoms)
-        for j in 1:num_orbitals[i]
+        for sublat_ind in 1:length(num_orbitals) ##JAP Modified this line to accomodate systems where number of atoms in unit cell does not equal number of sublattices (twisted bilayer)
+        for j in 1:num_orbitals[sublat_ind]
             push!(positions, position_atoms[i])
         end
     end
@@ -270,7 +271,7 @@ function set_prec(is_complex, precision)
         throw(ArgumentError("Precision should be 0, 1 or 2"))
         end
     else
-        if precision == 1
+        if precision == 0
             htype = ComplexF16
         elseif precision == 1
             htype = ComplexF32

--- a/src/kite_wrapper.jl
+++ b/src/kite_wrapper.jl
@@ -203,6 +203,14 @@ function site_positions(h) # site positions for each orbital in the TB matrix
     return positions
 end
 
+function get_num_orbitals(h) #JAP Calculate total number of orbitals in unit cell 
+
+    orb_per_sublat = h.blockstruct.subsizes
+    atomic_orb = h.blockstruct.blocksizes
+
+    return orb_per_sublat' * atomic_orb
+end
+
 function hdf5_rearrangefunction(h, energy_scale, energy_shift, space_size)
     h_info = hdf5_hamiltonian(h, energy_scale, energy_shift)
     # list of origin orbital indices for all dns


### PR DESCRIPTION
Proposal to fix two erros:

The first error happens when you try to create an hdf5 file for the twisted bilayer, for example. An example of the unit cell is plotted below:

![Screenshot 2025-01-31 at 15 54 49](https://github.com/user-attachments/assets/8e7d1ccb-4f60-4b5b-806f-07cf98204ad3)

I have removed the hoppings for better viewing. 

From my understanding, since the creation of this bilayer was used from the HP module which generates this supercell from two graphene sheets with two sublattices each, Quantica records this lattice as having four sublattices: Ab, Bb; At; Bt (Each plotted with a different color). The system, however, has more than one site per unit cell. Therefore, the number of sublattices in Quantica does not necessarily equal the number of sites per unit cell. This will be important later.

When you try creating the hdf5 file for this system, an error happens:

<img width="757" alt="Screenshot 2025-01-31 at 17 04 07" src="https://github.com/user-attachments/assets/d3f9e4f8-d782-421c-9364-4e1b6b959051" />

The error comes from the function site_positions which is defined as:

<img width="566" alt="Screenshot 2025-01-31 at 16 05 11" src="https://github.com/user-attachments/assets/455096c8-a6ef-43af-9fc5-9861f5b9b649" />


The purpose of this function is , I think, to generate a matrix with the coordinates in real space of every site inside the unit cell, with a degenerancy for the number of atomic orbitals. The matrix position_atoms is therefore a matrix of shape (Number of Atoms in unit cell,Dimension of problem). Now, the reason I think this error is occuring is because this Quantica.norbitals function seems to return an array of size = The number of sublattices in the system (in this case, 4), with each entry being the number of atomic orbitals per site of that sublattice. Because i is running on the number of rows of position_atoms, wich is of length + Number of Atoms in unit Cell, num_orbitals[i] is bound to go out of bounds eventually. In my understanding, this function only works if the number of sites per unit cell equals the number of sublattices in Quantica.

I propose the following change: 

<img width="1329" alt="Screenshot 2025-01-31 at 17 18 47" src="https://github.com/user-attachments/assets/8804f42b-379f-4351-91ed-ddd4d1df723f" />


This way, sublat_ind is ensured to run over the number of sublattices of the system, the inner cicle does not go out of bounds and the final positions array has the desired outcome of being equal to the position_atoms matrix with repeated entries for the number of atomic orbitals in the system. With this modification, the program no longer gives an error and the hdf5 file is produced. 


The second error has to do with the precision for complex numbers, which is written in the code as 

![Screenshot 2025-01-28 at 15 06 05](https://github.com/user-attachments/assets/005ee1ed-14ef-4d02-ae1f-fb6596cfb177)

I believe the first precision == 1 is a typo and changed it to precision == 0.
